### PR TITLE
Capture all MIME types

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ const PuppeteerHar = require('puppeteer-har');
 ### har.start([options])
 - `options` <?[Object]> Optional
   - `path` <[string]> If set HAR file will be written at this path
+  - `saveResponse` <[bool]> Save response bodies to the HAR file
+  - `captureMimeTypes` <[Array]> An array of MIME types to capture. Defaults to "['text/html', 'application/json']". Including "*" causes all MIME types to be captured.
   - `useFetch` <[bool]> Will save response bodies using experimental Fetch domain.
 - returns: <[Promise]>
 

--- a/lib/PuppeteerHar.js
+++ b/lib/PuppeteerHar.js
@@ -158,7 +158,8 @@ class PuppeteerHar {
                     if (this.inProgress &&
                         response.status !== 204 &&
                         response.headers.location == null &&
-                        this.captureMimeTypes.includes(response.mimeType)
+                        (this.captureMimeTypes.includes("*") ||
+                                this.captureMimeTypes.includes(response.mimeType))
                     ) {
                         if (this.useFetch) { 
 			                if (requestId in this.bodies) {                                
@@ -200,6 +201,7 @@ class PuppeteerHar {
                                 ).toString('base64');
 
                             }, (reason) => {
+				params.response._error = reason.message;
                                 console.log("body fetch failed");
                                 // Resources (i.e. response bodies) are flushed after page commits
                                 // navigation and we are no longer able to retrieve them. In this


### PR DESCRIPTION
I wanted to be able to capture all response bodies, regardless of MIME type - trying to provide all as an array seemed like a poor option, so this modification allows specifying an array value "*" to always attempt to capture. It also records capture errors within the HAR output in a manner that follows the HAR spec for custom fields. 